### PR TITLE
set go 1.16 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-eng/shodan
 
-go 1.14
+go 1.16
 
 require (
 	github.com/andygrunwald/go-jira v1.14.0


### PR DESCRIPTION
Updated to match what shodan is actually built with.
